### PR TITLE
feat(workflows/linter): use bun instead of yarn

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -158,14 +158,19 @@ jobs:
           bun-version: latest
 
       - name: 📦 Enable Corepack
+        if: inputs.use-bun != true
         run: corepack enable
+
+      - name: 🛠 Use Bun (if `use-bun`)
+        if: inputs.use-bun == true
+        run: bun install
 
       - name: 📦 Install Dependencies (if `install:all`)
         if: inputs.install-all == true
         run: yarn -v && yarn && yarn install:all
 
       - name: 📦 Install Dependencies (if `install`)
-        if: inputs.install-all != true
+        if: inputs.install-all != true && inputs.use-bun != true
         run: yarn install
 
       - name: 🔑 Generate dummy keys

--- a/tests/numbers.js
+++ b/tests/numbers.js
@@ -1,4 +1,3 @@
-/* eslint-disable sonarjs/no-duplicate-string */
 /*
 
 	by SWR Audio Lab

--- a/tests/strings.js
+++ b/tests/strings.js
@@ -1,4 +1,3 @@
-/* eslint-disable sonarjs/no-duplicate-string */
 /*
 
 	by SWR Audio Lab


### PR DESCRIPTION
With `use-bun: true` option when using _linter.yml_ we will use bun over yarn for installation.

NOTE: `install-all` still relies on yarn.